### PR TITLE
Fix: Export SkipAheadModal from interactive components

### DIFF
--- a/src/components/interactive/index.ts
+++ b/src/components/interactive/index.ts
@@ -1,3 +1,4 @@
 export { default as StickyKeyTakeaway } from './StickyKeyTakeaway';
 export { default as QuizModal } from './QuizModal';
 export { default as CollapsibleCard } from './CollapsibleCard';
+export { default as SkipAheadModal } from './SkipAheadModal';


### PR DESCRIPTION
Addresses a build error caused by SkipAheadModal not being exported from src/components/interactive/index.ts.

This commit adds the necessary export statement, allowing the component to be correctly imported and resolving the build failure.